### PR TITLE
feat: add OpenRouter API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,11 @@ This pipeline uses a frontier LLM with web search to label entities and align to
 
 ```bash
 export ANTHROPIC_API_KEY=...   # for annotation
+export OPENROUTER_API_KEY=...  # alternatively, use OpenRouter
 export HF_WRITE_TOKEN=...      # to push to HF datasets
 ```
+
+If `OPENROUTER_API_KEY` is set, the pipeline uses the OpenRouter API for LLM calls.
 
 Run (see `annotation_pipeline/README.md` and `run.py` for full arguments):
 

--- a/annotation_pipeline/run.py
+++ b/annotation_pipeline/run.py
@@ -34,7 +34,9 @@ logger = logging.getLogger(__name__)
 load_dotenv()
 
 # Ensure required environment variables are set
-assert os.environ.get('ANTHROPIC_API_KEY', None) is not None, "ANTHROPIC_API_KEY is not set"
+openrouter_key = os.environ.get("OPENROUTER_API_KEY")
+if openrouter_key is None:
+    assert os.environ.get('ANTHROPIC_API_KEY', None) is not None, "ANTHROPIC_API_KEY is not set"
 assert os.environ.get('HF_WRITE_TOKEN', None) is not None, "HF_WRITE_TOKEN is not set (needed for pushing to HF hub)"
 
 LOCAL_RESULTS_DIR = Path(__file__).parent.parent / "annotation_pipeline_results"
@@ -343,12 +345,16 @@ async def main(cfg: PipelineConfig):
         logger.info("No items to process. All items have already been processed.")
         return
     
-    inference_api = InferenceAPI(
-        cache_dir=cfg.safetytooling_cache_dir,
-        anthropic_num_threads=cfg.max_concurrent_tasks,
-        openai_num_threads=cfg.max_concurrent_tasks,
-        deepseek_num_threads=cfg.max_concurrent_tasks,
-    )
+    if os.environ.get("OPENROUTER_API_KEY"):
+        from utils.openrouter_api import OpenRouterInferenceAPI
+        inference_api = OpenRouterInferenceAPI()
+    else:
+        inference_api = InferenceAPI(
+            cache_dir=cfg.safetytooling_cache_dir,
+            anthropic_num_threads=cfg.max_concurrent_tasks,
+            openai_num_threads=cfg.max_concurrent_tasks,
+            deepseek_num_threads=cfg.max_concurrent_tasks,
+        )
     
     if not cfg.parallel:
         # Sequential processing

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ plotly>=5.22.0
 streamlit>=1.33.0
 pandas>=2.1.0
 accelerate>=0.20.0
+httpx>=0.25.0

--- a/utils/openrouter_api.py
+++ b/utils/openrouter_api.py
@@ -1,0 +1,44 @@
+import os
+from typing import Any, List
+
+import httpx
+from safetytooling.data_models import Prompt, LLMResponse
+
+
+class OpenRouterInferenceAPI:
+    """Minimal async client for the OpenRouter API."""
+
+    def __init__(self, api_key: str | None = None, base_url: str = "https://openrouter.ai/api/v1") -> None:
+        self.api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
+        if self.api_key is None:
+            raise ValueError("OPENROUTER_API_KEY is not set")
+        self.base_url = base_url.rstrip("/")
+
+    async def __call__(
+        self,
+        model_id: str,
+        prompt: Prompt,
+        temperature: float = 0.0,
+        max_tokens: int = 8192,
+        **_: Any,
+    ) -> List[LLMResponse]:
+        """Send a chat completion request to OpenRouter."""
+        messages = [{"role": m.role.value, "content": m.content} for m in prompt.messages]
+        payload = {
+            "model": model_id,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{self.base_url}/chat/completions", json=payload, headers=headers, timeout=None
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            completion = data["choices"][0]["message"]["content"]
+        return [LLMResponse(completion=completion)]

--- a/utils/string_utils.py
+++ b/utils/string_utils.py
@@ -46,8 +46,8 @@ def normalize_for_matching(text: str) -> str:
         r'(?<=[^\W\d_])(?<![MmXx])(?=\d)|(?<=\d)(?=[^\W\d_])', ' ', text)
 
     # Step 2: Remove quotes and punctuation (but preserve decimals)
-    # This combines quote removal with punctuation removal in one regex
-    text = re.sub(r'[\'"`''""‛„:;()\[\]\-–—]|[.,](?!(?<=\d[.,])\d)', ' ', text)
+    # Use a raw string with minimal escaping to avoid invalid escape warnings
+    text = re.sub(r"[\'\"`‛„:;()\[\]\-–—]|[.,](?!(?<=\d[.,])\d)", " ", text)
 
     # Step 3: Normalize whitespace and lowercase
     text = re.sub(r'\s+', ' ', text).strip().lower()


### PR DESCRIPTION
## Summary
- allow annotation pipeline to fall back to OpenRouter when `OPENROUTER_API_KEY` is set
- add minimal OpenRouter async client
- document OpenRouter usage and add httpx dependency
- fix regex escaping in `normalize_for_matching` to remove invalid escape warning

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c1402f95c48332a5028f789b46bcfe